### PR TITLE
Allowing the user to select card reader

### DIFF
--- a/card/ICC.py
+++ b/card/ICC.py
@@ -57,7 +57,7 @@ class ISO7816(object):
     standard file tags available in "file_tags" class dictionnary
     """
     
-    dbg = 0
+    dbg = 5
     
     INS_dic = {
         0x04 : 'DEACTIVATE FILE',
@@ -141,7 +141,7 @@ class ISO7816(object):
         0xAB : 'Security Attribute expanded',
         }     
                
-    def __init__(self, CLA=0x00):
+    def __init__(self, CLA=0x00, reader=""):
         """
         connect smartcard and defines class CLA code for communication
         uses "pyscard" library services
@@ -150,7 +150,10 @@ class ISO7816(object):
         and self.coms attribute with associated "apdu_stack" instance
         """
         cardtype = AnyCardType()
-        cardrequest = CardRequest(timeout=1, cardType=cardtype)
+        if reader:
+          cardrequest = CardRequest(timeout=1, cardType=cardtype, readers=[reader])
+        else:
+          cardrequest = CardRequest(timeout=1, cardType=cardtype)
         self.cardservice = cardrequest.waitforcard()
         self.cardservice.connection.connect()
         self.reader = self.cardservice.connection.getReader()

--- a/card/ICC.py
+++ b/card/ICC.py
@@ -57,7 +57,7 @@ class ISO7816(object):
     standard file tags available in "file_tags" class dictionnary
     """
     
-    dbg = 5
+    dbg = 0
     
     INS_dic = {
         0x04 : 'DEACTIVATE FILE',

--- a/card/SIM.py
+++ b/card/SIM.py
@@ -100,12 +100,12 @@ class SIM(ISO7816):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self):
+    def __init__(self, reader=""):
         """
         initialize like an ISO7816-4 card with CLA=0xA0
         can also be used for USIM working in SIM mode,
         """
-        ISO7816.__init__(self, CLA=0xA0)
+        ISO7816.__init__(self, CLA=0xA0, reader=reader)
         
         if self.dbg >= 2:
             log(3, '(SIM.__init__) type definition: %s' % type(self))

--- a/card/USIM.py
+++ b/card/USIM.py
@@ -177,7 +177,7 @@ class USIM(UICC):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self):
+    def __init__(self, reader=""):
         """
         initializes like an ISO7816-4 card with CLA=0x00
         and checks available AID (Application ID) read from EF_DIR
@@ -185,7 +185,7 @@ class USIM(UICC):
         initializes on the MF
         """
         # initialize like a UICC
-        ISO7816.__init__(self, CLA=0x00)
+        ISO7816.__init__(self, CLA=0x00, reader=reader)
         self.AID = []
         
         if self.dbg >= 2:


### PR DESCRIPTION
It could be very useful in an environment with multiple cards connected to a single machine to be able to exactly specify the name of the reader to use instead of relying on possibly random selection. The change introduced keeps backward-compatibility via default empty parameters.