### PR TITLE
add SIM/USIM communication via modem AT commands

### DIFF
--- a/card/ICC.py
+++ b/card/ICC.py
@@ -142,7 +142,7 @@ class ISO7816(object):
         0xAB : 'Security Attribute expanded',
         }
     
-    def __init__(self, CLA=0x00, reader='', modem_device_path=''):
+    def __init__(self, CLA=0x00, reader='', modem_device_path='', at_client=None):
         """
         connect smartcard and defines class CLA code for communication
         uses "pyscard" library services
@@ -152,8 +152,8 @@ class ISO7816(object):
         """
 
         cardtype = AnyCardType()
-        if modem_device_path:
-            cardrequest = ModemCardRequest(modem_device_path, timeout=1, cardType=cardtype, readers=[reader])
+        if modem_device_path or at_client:
+            cardrequest = ModemCardRequest(at_client=at_client, modem_device_path=modem_device_path, timeout=1, cardType=cardtype, readers=[reader])
         else:
             cardrequest = CardRequest(timeout=1, cardType=cardtype, readers=[reader])
         self.cardservice = cardrequest.waitforcard()

--- a/card/ICC.py
+++ b/card/ICC.py
@@ -42,7 +42,8 @@ from smartcard.Exceptions import CardConnectionException
 from smartcard.util import toHexString
 
 from card.utils import *
-        
+from .modem.modem_card_request import ModemCardRequest
+
 ###########################################################
 # ISO7816 class with attributes and methods as defined 
 # by ISO-7816 part 4 standard for smartcard 
@@ -141,7 +142,7 @@ class ISO7816(object):
         0xAB : 'Security Attribute expanded',
         }
     
-    def __init__(self, CLA=0x00, reader=''):
+    def __init__(self, CLA=0x00, reader='', modem_device_path=''):
         """
         connect smartcard and defines class CLA code for communication
         uses "pyscard" library services
@@ -149,11 +150,12 @@ class ISO7816(object):
         creates self.CLA attribute with CLA code
         and self.coms attribute with associated "apdu_stack" instance
         """
+
         cardtype = AnyCardType()
-        if reader:
-            cardrequest = CardRequest(timeout=1, cardType=cardtype, readers=[reader])
+        if modem_device_path:
+            cardrequest = ModemCardRequest(modem_device_path, timeout=1, cardType=cardtype, readers=[reader])
         else:
-            cardrequest = CardRequest(timeout=1, cardType=cardtype)
+            cardrequest = CardRequest(timeout=1, cardType=cardtype, readers=[reader])
         self.cardservice = cardrequest.waitforcard()
         self.cardservice.connection.connect()
         self.reader = self.cardservice.connection.getReader()
@@ -1784,3 +1786,8 @@ class UICC(ISO7816):
         if hasattr(self, 'AID') and aid_num <= len(self.AID)+1:
             return self.select(self.AID[aid_num-1], 'aid')
 
+    def dispose(self):
+        try:
+            self.cardservice.dispose()
+        except:
+            pass

--- a/card/SIM.py
+++ b/card/SIM.py
@@ -100,12 +100,12 @@ class SIM(ISO7816):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self, reader='', modem_device_path=''):
+    def __init__(self, reader='', modem_device_path='', at_client=None):
         """
         initialize like an ISO7816-4 card with CLA=0xA0
         can also be used for USIM working in SIM mode,
         """
-        ISO7816.__init__(self, CLA=0xA0, reader=reader, modem_device_path=modem_device_path)
+        ISO7816.__init__(self, CLA=0xA0, reader=reader, modem_device_path=modem_device_path, at_client=at_client)
         #
         if self.dbg >= 2:
             log(3, '(SIM.__init__) type definition: %s' % type(self))

--- a/card/SIM.py
+++ b/card/SIM.py
@@ -100,12 +100,12 @@ class SIM(ISO7816):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self, reader=''):
+    def __init__(self, reader='', modem_device_path=''):
         """
         initialize like an ISO7816-4 card with CLA=0xA0
         can also be used for USIM working in SIM mode,
         """
-        ISO7816.__init__(self, CLA=0xA0, reader=reader)
+        ISO7816.__init__(self, CLA=0xA0, reader=reader, modem_device_path=modem_device_path)
         #
         if self.dbg >= 2:
             log(3, '(SIM.__init__) type definition: %s' % type(self))

--- a/card/USIM.py
+++ b/card/USIM.py
@@ -177,7 +177,7 @@ class USIM(UICC):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self, reader=''):
+    def __init__(self, reader='', modem_device_path=''):
         """
         initializes like an ISO7816-4 card with CLA=0x00
         and checks available AID (Application ID) read from EF_DIR
@@ -185,7 +185,7 @@ class USIM(UICC):
         initializes on the MF
         """
         # initialize like a UICC
-        ISO7816.__init__(self, CLA=0x00, reader=reader)
+        ISO7816.__init__(self, CLA=0x00, reader=reader, modem_device_path=modem_device_path)
         self.AID        = []
         self.AID_GP     = {}
         self.AID_USIM   = None

--- a/card/USIM.py
+++ b/card/USIM.py
@@ -177,7 +177,7 @@ class USIM(UICC):
     use self.dbg = 1 or more to print live debugging information
     """
     
-    def __init__(self, reader='', modem_device_path=''):
+    def __init__(self, reader='', modem_device_path='', at_client=None):
         """
         initializes like an ISO7816-4 card with CLA=0x00
         and checks available AID (Application ID) read from EF_DIR
@@ -185,7 +185,7 @@ class USIM(UICC):
         initializes on the MF
         """
         # initialize like a UICC
-        ISO7816.__init__(self, CLA=0x00, reader=reader, modem_device_path=modem_device_path)
+        ISO7816.__init__(self, CLA=0x00, reader=reader, modem_device_path=modem_device_path, at_client=at_client)
         self.AID        = []
         self.AID_GP     = {}
         self.AID_USIM   = None

--- a/card/modem/at_command_client.py
+++ b/card/modem/at_command_client.py
@@ -1,0 +1,53 @@
+import time
+import serial
+from typing import Optional, Union, Callable, Any
+
+class ATCommandClient:
+
+    def __init__(self, device_path: str, timeout: Optional[float] = 1.0) -> None:
+        if timeout < 0.5:
+            timeout = 0.5
+
+        self._device_path = device_path
+        self._timeout = timeout
+        self._serial = None
+
+    def connect(self) -> None:
+        if self._serial:
+            return
+
+        self._serial = serial.Serial(
+            self._device_path, 
+            115200, 
+            timeout=0.001,
+        )
+
+    def transmit(self, at_command: Union[str, bytes], transform: Optional[Callable[[str, str], Any]] = lambda x,y: y) -> Union[str, Any]:
+        if not self._serial:
+            raise ValueError("Client shall be connected")
+        
+        if isinstance(at_command, bytes):
+            at_command = at_command.decode()
+
+        if at_command[-2::] != "\r\n":
+            at_command += "\r\n"
+
+        at_command = at_command.encode()
+        self._serial.write(at_command)
+
+        resp = b''
+        read_until = time.time() + self._timeout
+        while b'OK' not in resp and b'ERROR' not in resp:        
+            resp += self._serial.read(256)
+            if time.time() > read_until:
+                break
+
+        return transform(at_command, resp.decode())
+
+    def dispose(self) -> None:
+        if not self._serial:
+            return
+
+        self._serial.close()
+        self._serial = None        
+    

--- a/card/modem/modem_card_request.py
+++ b/card/modem/modem_card_request.py
@@ -8,9 +8,16 @@ from .at_command_client import ATCommandClient
 logger = logging.getLogger("modem")
 
 class ModemCardRequest:
-    def __init__(self, modem_device_path, timeout: int = 1, cardType: CardType = AnyCardType, readers: Optional[Iterable[str]] = None) -> None:
+    def __init__(self, at_client: Optional[ATCommandClient] = None, modem_device_path: Optional[str] = None, timeout: int = 1, cardType: CardType = AnyCardType, readers: Optional[Iterable[str]] = None) -> None:
         self._readers = readers or ['']
-        self._client = ATCommandClient(modem_device_path, timeout=float(timeout))
+        if not at_client and not modem_device_path:
+            raise ValueError("Either at_client or modem_device_path shall be configured")
+
+        if modem_device_path:
+            self._client = ATCommandClient(modem_device_path, timeout=float(timeout))
+
+        if at_client:
+            self._client = at_client
 
     @property
     def connection(self) -> Any:

--- a/card/modem/modem_card_request.py
+++ b/card/modem/modem_card_request.py
@@ -1,0 +1,95 @@
+import logging
+import time
+from typing import Any, Iterable, Optional, List, Tuple
+from smartcard.CardType import AnyCardType, CardType
+from serial import SerialException
+from .at_command_client import ATCommandClient
+
+logger = logging.getLogger("modem")
+
+class ModemCardRequest:
+    def __init__(self, modem_device_path, timeout: int = 1, cardType: CardType = AnyCardType, readers: Optional[Iterable[str]] = None) -> None:
+        self._readers = readers or ['']
+        self._client = ATCommandClient(modem_device_path, timeout=float(timeout))
+
+    @property
+    def connection(self) -> Any:
+        return self
+
+    def waitforcard(self) -> None:
+        self.connect()
+        return self
+
+    def connect(self) -> None:
+        self._client.connect()
+
+    def getReader(self) -> Any:
+        return self._readers
+    
+    def getATR(self) -> Any:
+        return None
+    
+    def transmit(self, apdu: List[int]) -> Any:
+        """
+            Transmits SIM APDU to the modem.
+        """
+
+        at_command = self._to_csim_command(apdu)
+        data, sw1, sw2 = [], 0xff, 0xff
+
+        try:
+            while sw1 == 0xff and sw2 == 0xff:
+                data, sw1, sw2 = self._client.transmit(at_command, self._at_response_to_card_response)
+        except SerialException as e:
+            logger.debug("Serial communication error << {e} ... retrying") # for faulty, unstable cards
+
+        logger.debug(f"""
+            APDU << {apdu}
+            AT Command << {at_command}
+            Ret << data:{data}, sw1:{sw1}, sw2:{sw2}
+        """)
+        return (data, sw1, sw2)
+        
+    def _to_csim_command(self, apdu: List[int]) -> str:
+        """
+            Transforms a SIM APDU represented as a list of integers (bytes data)
+            into its corresponding AT+CSIM command format.
+        """
+
+        at_command = ("").join(map(lambda x: "%0.2X" % x, apdu))
+        at_command = f'AT+CSIM={len(at_command)},"{at_command}"'
+        return at_command
+
+    def _at_response_to_card_response(self, at_command: str, at_response: str) -> Tuple[List[int], int, int]:
+        """
+            Transforms AT response to the expected CardService format.
+        """
+
+        parts = list(filter(lambda x: x != '', at_response.split("\r\n")))
+        if len(parts) == 0:
+            return [], 0xff, 0xff # communication error
+
+        if not parts[-1] or 'ERROR' in parts[-1]:
+            return [], 0x6f, 0x0 # checking error: no precise diagnosis
+        
+        res = parts[0]
+        res = res[res.find('"')+1:-1:]
+
+        return (
+            self._hexstream_to_bytes(res[:-4:]),
+            int(res[-4:-2:], 16),
+            int(res[-2::], 16)
+        )
+
+    def _hexstream_to_bytes(self, hexstream: str) -> List[int]:
+        """
+            Returns a list of integers representing byte data from a hexadecimal stream.
+        """
+
+        return list(
+            map(
+                lambda x: int(x, 16),
+                [hexstream[i:i+2] for i in range(0, len(hexstream), 2)]
+            )
+        ) 
+

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,18 @@ setup(
     
     packages=[
         "card"
-        ],
+    ],
     
     # mandatory dependency
     install_requires=[
-      'pyscard'
-        ],
+        'pyscard',
+        'pyserial'
+    ],
     
     # optional dependency
     extras_require={
         'graph': ['pydot', 'graphviz']
-        },
+    },
     
     author="Benoit Michau",
     author_email="michau.benoit@gmail.com",


### PR DESCRIPTION
This PR will add support for SIM/USIM communication via a modem device using the AT+CSIM command. It has been tested with a USIM:
```
from card.USIM import *

usim = USIM(modem_device_path="/dev/ttyUSB2")
print(f"IMSI << {usim.get_imsi()}")
print(f"get_services << {usim.get_services()}")
usim.dispose()
```
```
In [1]: %ed a.py
Editing... done. Executing edited code...
IMSI << 001010000104267  
get_services << ['2 : Fixed Dialling Numbers (FDN) : available', '3 : Extension 2 : available', '4 : Service Dialling Numbers (SDN) : available', '5 : Extension3 : available', '6 : Barred Dialling Numbers (BDN) : available', '8 : Outgoing Call Information (OCI and OCT) : available', '9 : Incoming Call Information (ICI and ICT) : available', '10 : Short Message Storage (SMS) : available', '11 : Short Message Status Reports (SMSR) : available', '12 : Short Message Service Parameters (SMSP) : available', '13 : Advice of Charge (AoC) : available', '14 : Capability Configuration Parameters 2 (CCP2) : available', '15 : Cell Broadcast Message Identifier  : available', '16 : Cell Broadcast Message Identifier Ranges  : available', '17 : Group Identifier Level 1 : available', '18 : Group Identifier Level 2 : available', '19 : Service Provider Name : available', '20 : User controlled PLMN selector with Access Technology : available', '21
 : MSISDN : available', '24 : Enhanced Multi-Level Precedence and Pre-emption Service : available', '25 : Automatic Answer for eMLPP : available', '27 : GSM Access : available', '28 : Data download via SMS-PP : available', '29 : Data download via SMS-CB : available', '32 : RUN AT COMMAND command : available', "33 : shall be set to '1' : available", '34 : Enabled Services Table : available', '35 : APN Control List (ACL) : available', '38 : GSM security context  : available', '39 : CPBCCH Information : available', '40 : Investigation Scan : available', '42 : Operator controlled PLMN selector with Access Technology : available', '43 : HPLMN selector with Access Technology : available', '44 : Extension 5 : available', '45 : PLMN Network Name : available', '46 : Operator PLMN List : available', '51 : Service Provider Display Information : available', '60 : User Controlled PLMN selector for I-WLAN access : available', '81 : Home I-WLAN Specific Identifier List : available', '82 : I-WLAN Equivalent HPLMN Presentation Indication : available', '83 : I-WLAN HPLMN Priority Indication : available', '84 : I-WLAN Last Registered PLMN : available', '85 : EPS Mobility Management Information : available', '86 : Allowed CSG Lists and corresponding indications : available', '87 : Call control on EPS PDN connection by USIM : available', '88 : HPLMN Direct Access : available', '89 : eCall Data : available', '90 : Operator CSG Lists and corresponding indications : available', '93 : Communication Control for IMS by USIM : available', '94 : Extended Terminal Applications : available', '122 : 5GS Mobility Management Information : available', '123 : 5G Security Parameters : available']

```

It should theoretically work with the SIM class as well, but it hasn't been tested.